### PR TITLE
fix: support js lang

### DIFF
--- a/config/style.tex
+++ b/config/style.tex
@@ -17,36 +17,16 @@
         tabsize=4
 }
 
-% Define TypeScript code style
-\lstset{language=TypeScript, 
-        basicstyle=\ttfamily\small, 
-        keywordstyle=\color{blue},
-        commentstyle=\color{green},
-        stringstyle=\color{red},
-        showstringspaces=false,
-        numbers=left,
-        numberstyle=\tiny,
-        stepnumber=1,
-        numbersep=5pt,
-        frame=single,
-        breaklines=true,
-        breakatwhitespace=true,
-        tabsize=2
-}
-
-% Define Go code style
-\lstset{language=Go, 
-        basicstyle=\ttfamily\small, 
-        keywordstyle=\color{blue},
-        commentstyle=\color{green},
-        stringstyle=\color{red},
-        showstringspaces=false,
-        numbers=left,
-        numberstyle=\tiny,
-        stepnumber=1,
-        numbersep=5pt,
-        frame=single,
-        breaklines=true,
-        breakatwhitespace=true,
-        tabsize=4
-}
+\lstdefinelanguage{JavaScript}{
+  morekeywords=[1]{break, continue, delete, else, for, function, if, in, new, return, this, typeof, var, void, while, with},
+  % Literals, primitive types, and reference types.
+  morekeywords=[2]{false, null, true, boolean, number, undefined, Array, Boolean, Date, Math, Number, String, Object},
+  % Built-ins.
+  morekeywords=[3]{eval, parseInt, parseFloat, escape, unescape},
+  sensitive,
+  morecomment=[s]{/*}{*/},
+  morecomment=[l]//,
+  morecomment=[s]{/**}{*/}, % JavaDoc style comments
+  morestring=[b]',
+  morestring=[b]"
+}[keywords, comments, strings]


### PR DESCRIPTION
Please ensure your pull request adheres to the following guidelines:

## Summary by Sourcery

Add JavaScript support by defining a custom JavaScript language for LaTeX listings and clean up outdated TypeScript and Go configurations

New Features:
- Introduce JavaScript language definition for syntax highlighting in LaTeX listings

Enhancements:
- Remove legacy TypeScript and Go listing style definitions from style.tex

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Style**
  - Updated syntax highlighting configuration to support JavaScript code listings with improved keyword, comment, and string recognition.
  - Removed previous custom styling for TypeScript and Go code listings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->